### PR TITLE
XWiki Image plugin - configuration

### DIFF
--- a/app/views/excursions/edit.full.erb
+++ b/app/views/excursions/edit.full.erb
@@ -20,6 +20,10 @@
 	configuration["ViSH"] = true;
 	configuration["ViSH_instances"] = ["<%= Vish::Application.config.full_domain %>"];
 	configuration["Flickr"] = true;
+	<% unless Vish::Application.config.APP_CONFIG['xwiki_url'].nil? %>
+		configuration["XWiki"] = true;
+		configuration["XWiki_url"] =  "<%= Vish::Application.config.APP_CONFIG['xwiki_url'] %>";
+	<% end %>
 	<% unless Vish::Application.config.APP_CONFIG['EuropeanaAPIKEY'].nil? %>
 		configuration["Europeana"] = true;
 		configuration["EuropeanaAPIKEY"] =  "<%= Vish::Application.config.APP_CONFIG['EuropeanaAPIKEY'] %>";

--- a/app/views/excursions/new.full.erb
+++ b/app/views/excursions/new.full.erb
@@ -20,6 +20,10 @@
 	configuration["ViSH"] = true;
 	configuration["ViSH_instances"] = ["<%= Vish::Application.config.full_domain %>"];
 	configuration["Flickr"] = true;
+	<% unless Vish::Application.config.APP_CONFIG['xwiki_url'].nil? %>
+		configuration["XWiki"] = true;
+		configuration["XWiki_url"] =  "<%= Vish::Application.config.APP_CONFIG['xwiki_url'] %>";
+	<% end %>
 	<% unless Vish::Application.config.APP_CONFIG['EuropeanaAPIKEY'].nil? %>
 		configuration["Europeana"] = true;
 		configuration["EuropeanaAPIKEY"] =  "<%= Vish::Application.config.APP_CONFIG['EuropeanaAPIKEY'] %>";

--- a/config/application_config.yml.example
+++ b/config/application_config.yml.example
@@ -158,6 +158,9 @@ test:
 # twitter:
 #   enable: true
 
+# XWiki (http://www.xwiki.org)
+# xwiki_url: "http://localhost:8080/xwiki/bin/view/"
+
 # Google Plus (http://plus.google.com/)
 # gplus:
 #   enable: true


### PR DESCRIPTION
The configuration required in the VISH platform in order to be able to use the XWiki Image plugin in the Vish Editor (see https://github.com/ging/vish_editor/pull/74 )
